### PR TITLE
feat: automatically determine sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ Don't forget to make a backup of the `mySources` variable if you are updating fr
 5. Save the script.
 6. Reload DnDBeyond page.
 
+## How to automatically determine sources
+1. visit the [sources](https://www.dndbeyond.com/sources) page on DnDBeyond to save all of your owned sources to your browser.
+2. Visit the content management page of a campaign that is sharing sources with you to save the shared sources for the current campaign to your browser. Note that only sources from one campaign at a time can be saved.
+  example url: `https://www.dndbeyond.com/campaigns/<campaign_id>/content-management`
+
+If any sources have been saved, the `mySources` variable will be overridden.
+
 ## Links
 [Greasy Fork](https://greasyfork.org/en/scripts/451010-beyond-my-sources)
 

--- a/script.js
+++ b/script.js
@@ -3,7 +3,7 @@
 // @namespace   Violentmonkey Scripts
 // @match       https://www.dndbeyond.com/*
 // @grant       none
-// @version     2.3.2
+// @version     2.3.3
 // @author      Petr Gondek
 // @description Adds a button to DnDBeyond to filter sources you own.
 // @license MIT

--- a/script.js
+++ b/script.js
@@ -14,18 +14,18 @@ window.addEventListener('load', function() {
 }, false);
 
 function safeParse(jsonString) {
-    try {
-        return JSON.parse(jsonString)
-    } catch (error) {
-        return null
-    }
+  try {
+    return JSON.parse(jsonString)
+  } catch (error) {
+    return null
+  }
 }
 // Execute this to get new sources array
 //Array.from(document.getElementById("filter-source")).map(e => e.id);
 
-const localStorageSourceKey = 'DNDB_OWNED_SOURCES'
+const localStorageOwnedSourcesKey = 'DNDB_OWNED_SOURCES'
 function getSourceFilters() {
-  const ownedSources = safeParse(window.localStorage.getItem(localStorageSourceKey))
+  const ownedSources = safeParse(window.localStorage.getItem(localStorageOwnedSourcesKey))
 
   if (Array.isArray(ownedSources)) {
     return ownedSources.map(source => `filter-source-${source}`)
@@ -43,7 +43,7 @@ function getSourceFromTitle(title) {
   return title.replace(/[^a-zA-Z0-9\s]/g, '').trim().replace(/\s/g, '-').toLowerCase();
 }
 
-function saveSources(sources) {
+function saveOwnedSources(sources) {
   // delete all rendered sources not in library
   const sourceListings = getSourceListings()
   const filteredSourceListings = sourceListings.filter(listing => Boolean(listing.querySelector('.owned-content')))
@@ -59,7 +59,7 @@ function saveSources(sources) {
   })
 
   if (ownedSources.length) {
-    window.localStorage.setItem(localStorageSourceKey, JSON.stringify(ownedSources))
+    window.localStorage.setItem(localStorageOwnedSourcesKey, JSON.stringify(ownedSources))
   }
 }
 
@@ -203,7 +203,7 @@ function Main() {
   }, 2000);
 
   if (IsSourceList()) {
-    saveSources()
+    saveOwnedSources()
   }
 
 }

--- a/script.js
+++ b/script.js
@@ -64,6 +64,7 @@ function saveOwnedSources() {
   })
 
   if (ownedSources.length) {
+    ownedSources.sort()
     window.localStorage.setItem(localStorageOwnedSourcesKey, JSON.stringify(ownedSources))
   }
 }
@@ -76,6 +77,7 @@ function saveSharedSources() {
   })
 
   if (sharedSources.length) {
+    sharedSources.sort()
     window.localStorage.setItem(localStorageSharedSourcesKey, JSON.stringify(sharedSources))
   }
 }

--- a/script.js
+++ b/script.js
@@ -239,8 +239,7 @@ function IsCampaignContent() {
   const pathComponents = window.location.pathname.split('/').reverse().filter(i => i)
   const isContentManagementPage = pathComponents[0] == 'content-management'
   const campaignId = pathComponents[1]
-  const isCampaign = pathComponents[2] = 'campaigns'
-
+  const isCampaign = pathComponents[2] === 'campaigns'
   return isCampaign && isContentManagementPage
 }
 

--- a/script.js
+++ b/script.js
@@ -222,7 +222,7 @@ function Main() {
 }
 
 function IsSourceList() {
-  const pageTitle = document.querySelector('h1.page-title').textContent
+  const pageTitle = document.querySelector('h1.page-title').textContent.trim()
   return pageTitle == "Sources"
 }
 

--- a/script.js
+++ b/script.js
@@ -36,8 +36,6 @@ function getSourceFilters() {
   return allSources.map(source => `filter-source-${source}`)
 }
 
-const SOURCE_LISTING_CLASS_NAME = 'sources-listing'
-
 function getSourceFromTitle(title) {
   return title.replace(/[^a-zA-Z0-9\s]/g, '').trim().replace(/\s/g, '-').toLowerCase();
 }

--- a/script.js
+++ b/script.js
@@ -13,7 +13,8 @@ window.addEventListener('load', function() {
     Main();
 }, false);
 
-function safeSourceParse(jsonString) {
+function safeSourceParse(sourceKey) {
+  const jsonString = window.localStorage.getItem(sourceKey)
   try {
     const parsedSources = JSON.parse(jsonString)
     if (Array.isArray(parsedSources)) return parsedSources
@@ -28,12 +29,12 @@ function safeSourceParse(jsonString) {
 const localStorageOwnedSourcesKey = 'DNDB_OWNED_SOURCES'
 const localStorageSharedSourcesKey = 'DNDB_SHARED_SOURCES'
 function getSourceFilters() {
-  const ownedSources = safeSourceParse(window.localStorage.getItem(localStorageOwnedSourcesKey))
-  const sharedSources = safeSourceParse(window.localStorage.getItem(localStorageSharedSourcesKey))
+  const ownedSources = safeSourceParse(localStorageOwnedSourcesKey)
+  const sharedSources = safeSourceParse(localStorageSharedSourcesKey)
 
   const allSources = [...ownedSources, ...sharedSources]
   const uniqueSources = [...new Set(allSources)];
-  return allSources.map(source => `filter-source-${source}`)
+  return uniqueSources.map(source => `filter-source-${source}`)
 }
 
 function getSourceFromTitle(title) {

--- a/script.js
+++ b/script.js
@@ -38,7 +38,14 @@ function getSourceFilters() {
 }
 
 function getSourceFromTitle(title) {
-  return title.replace(/[^a-zA-Z0-9\s]/g, '').trim().replace(/\s/g, '-').toLowerCase();
+  const sourceName = title
+    .toLowerCase()
+    .trim()
+    .replace(/&/g, '-')
+    .replace(/\s/g, '-')
+    .replace(/[^a-zA-Z0-9-\s]/g, '')
+
+  return sourceName
 }
 
 function saveOwnedSources() {
@@ -222,7 +229,7 @@ function Main() {
 }
 
 function IsSourceList() {
-  const pageTitle = document.querySelector('h1.page-title').textContent.trim()
+  const pageTitle = document.querySelector('h1.page-title')?.textContent.trim()
   return pageTitle == "Sources"
 }
 
@@ -252,11 +259,7 @@ function OnClickEncounterBuilder(){
   let ele = document.getElementsByClassName(QA_MONSTER_FILTERS_SOURCE)[0].getElementsByClassName(INPUT_SELECT_DROPDOWN)[0];
   let clickables = Array.from(ele.childNodes).map(e=> e.firstElementChild);
   clickables.forEach(e => {
-    let bookName = e.getElementsByClassName(INPUT_CHECKBOX_TEXT)[0].firstChild.data
-      .toLowerCase()
-      .replace(/\s/g, '-')
-      .replace(/&/g,'-') // removes & from 'D&D Free Rules'
-      .replace(/[^a-zA-Z-]/g, '');
+    let bookName = getSourceFromTitle(e.getElementsByClassName(INPUT_CHECKBOX_TEXT)[0].firstChild.data)
     if (mySources.some(source => source.includes(bookName)))
       e.click();
   });


### PR DESCRIPTION
Rather than using the array of sources to determine which sources should appear in the automatic filter, this PR will determine the user's available sources directly from the DnDBeyond sources and campaign-content pages.

In this initial version, shared sources can only be saved from one campaign at a time.